### PR TITLE
fix: refs de bussiness inconsistentes y validación de ObjectId en flotillas

### DIFF
--- a/controllers/FlotillasController.js
+++ b/controllers/FlotillasController.js
@@ -223,13 +223,22 @@ module.exports = {
     const { id } = req.params
     const { type } = req.query
 
+    if (!id || !type) {
+      return res.status(400).json({ message: 'id y type son requeridos' })
+    }
+    if (['traslado', 'flete', 'renta'].indexOf(type) === -1) {
+      return res.status(400).json({ message: `type inválido: ${type}` })
+    }
+
     try {
       const response = await FlotillasServices.getById(id, type)
-      if (response) {
-        return res.status(200).json({ [type]: response })
+      if (!response) {
+        return res.status(404).json({ message: 'Documento no encontrado' })
       }
+      return res.status(200).json({ [type]: response })
     } catch (error) {
-      return res.status(400).json({ message: error })
+      console.error('GET /flotilla/get/:id error:', error.message)
+      return res.status(400).json({ message: error.message })
     }
   },
   updateVehiculo: async (req, res) => {

--- a/models/Flete.js
+++ b/models/Flete.js
@@ -98,7 +98,7 @@ const FleteSchema = new Schema({
   },
   bussiness_cost: [{
     type: mongoose.Schema.Types.ObjectId,
-    ref: 'bussinesses'
+    ref: 'bussiness'
   }],
   route: {
     type: JSON
@@ -108,7 +108,7 @@ const FleteSchema = new Schema({
   },
   client: {
     type: mongoose.Schema.Types.ObjectId,
-    ref: 'businesses'
+    ref: 'bussiness'
   },
   link_googlemaps: {
     type: String

--- a/models/Flotilla.js
+++ b/models/Flotilla.js
@@ -34,7 +34,7 @@ const FlotillasSchema = new Schema({
     }, 
     bussiness_cost: {
       type: mongoose.Schema.Types.ObjectId,
-      ref: 'bussinesses',
+      ref: 'bussiness',
     },
     picture: {
       type: String,      

--- a/models/Rentas.js
+++ b/models/Rentas.js
@@ -98,7 +98,7 @@ const RentasSchema = new Schema({
     }, 
     bussiness_cost: {
         type: mongoose.Schema.Types.ObjectId,
-        ref: 'bussinesses',
+        ref: 'bussiness',
     },
     route: {
         type: JSON,
@@ -108,7 +108,7 @@ const RentasSchema = new Schema({
     },
     client: {
         type: mongoose.Schema.Types.ObjectId,
-        ref: 'businesses',
+        ref: 'bussiness',
     },
     link_googlemaps: {
         type: String,

--- a/models/Traslado.js
+++ b/models/Traslado.js
@@ -98,7 +98,7 @@ const TrasladoSchema = new Schema({
     },
     bussiness_cost: {
         type: mongoose.Schema.Types.ObjectId,
-        ref: 'bussinesses',
+        ref: 'bussiness',
     },
     route: {
         type: JSON,
@@ -108,7 +108,7 @@ const TrasladoSchema = new Schema({
     },
     client: {
         type: mongoose.Schema.Types.ObjectId,
-        ref: 'businesses',
+        ref: 'bussiness',
     },
     link_googlemaps: {
         type: String,

--- a/services/FlotillasService.js
+++ b/services/FlotillasService.js
@@ -164,6 +164,11 @@ module.exports = {
     return empresa
   },
   getDocumentsByIdBussiness: async ({ idBussines, query }) => {
+    if (!mongoose.Types.ObjectId.isValid(idBussines)) {
+      const err = new Error(`idBussines inválido: ${idBussines}`)
+      err.statusCode = 400
+      throw err
+    }
     const aggCanceled = viewDocumentsCanceled(new mongoose.Types.ObjectId(idBussines))
     const aggNormal = viewDocumentsNormal(new mongoose.Types.ObjectId(idBussines))
 

--- a/services/FlotillasService.js
+++ b/services/FlotillasService.js
@@ -248,17 +248,17 @@ module.exports = {
   getById: async (id, type) => {
     switch (type) {
       case 'flete':
-        const flotilla = await Flete.findById({ _id: id })
+        const flotilla = await Flete.findById(id)
           .populate('client', 'name slug')
           .populate('bussiness_cost', 'name slug')
         return flotilla
       case 'traslado':
-        const traslado = await Traslado.findById({ _id: id })
+        const traslado = await Traslado.findById(id)
           .populate('client', 'name slug')
           .populate('bussiness_cost', 'name slug')
         return traslado
       case 'renta':
-        const renta = await Rentas.findById({ _id: id })
+        const renta = await Rentas.findById(id)
           .populate('client', 'name slug')
           .populate('bussiness_cost', 'name slug')
         return renta


### PR DESCRIPTION
## Problema

Dos errores en runtime sobre el módulo de flotillas:

1. **`Schema hasn't been registered for model "businesses"`** en `GET /flotilla/get/:id` (`getById`). Los campos `client` y `bussiness_cost` en los modelos referenciaban nombres de modelo que no existen (`businesses`, `bussinesses`), pero el modelo realmente registrado es `bussiness` (definido inline en `services/FlotillasService.js`). El `populate` fallaba y devolvía 400 para todos los documentos.

2. **`BSONError: Argument passed in must be a string of 12 bytes or a string of 24 hex characters`** en `getDocumentsByIdBussiness` (`services/FlotillasService.js:167`). Un `idBussines` inválido reventaba al construir `new mongoose.Types.ObjectId(idBussines)`.

## Cambios

- Alinea todos los `ref` (`client`, `bussiness_cost`) al modelo registrado `bussiness` en `Flete`, `Traslado`, `Rentas` y `Flotilla`.
- Valida `idBussines` con `ObjectId.isValid` antes de construir el `ObjectId`; si es inválido lanza error con `statusCode 400` y mensaje claro en lugar de un `BSONError`.

## Verificación

- Carga de modelos sin error; los `ref` de `client` y `bussiness_cost` resuelven a `bussiness` en los 4 modelos.
- `ObjectId.isValid(undefined)` → `false` (guard activo), `isValid("<24hex>")` → `true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)