### PR TITLE
fix: gasolina como monto fijo en payload de PDF (desglose inflado)

### DIFF
--- a/services/FlotillasService.js
+++ b/services/FlotillasService.js
@@ -36,7 +36,7 @@ const mapDocumentBody = (type, body = {}) => {
     per_diem_unit:    body.per_diem_unit || 'dia',
     per_diem_days:    toNumber(body.per_diem_days),
     gasoline_rate:    toNumber(body.gasoline_rate),
-    gasoline_unit:    body.gasoline_unit || 'km',
+    gasoline_unit:    body.gasoline_unit || 'fijo',
     gasoline_km:      toNumber(body.gasoline_km ?? body.recorrido_km),
     unit_rent_amount: toNumber(body.unit_rent_amount),
     unit_rent_period: body.unit_rent_period || 'dia',

--- a/services/PDFServices.js
+++ b/services/PDFServices.js
@@ -1010,7 +1010,7 @@ module.exports = {
         casetas_notes: plainCostBreakdown.casetas_notes || '',
         operator_unit: plainCostBreakdown.operator_unit || 'dia',
         per_diem_unit: plainCostBreakdown.per_diem_unit || 'dia',
-        gasoline_unit: plainCostBreakdown.gasoline_unit || 'km',
+        gasoline_unit: 'fijo', // spec §3.4: gasolina siempre monto fijo, nunca por km. gasoline_km queda solo informativo.
         unit_rent_unit: plainCostBreakdown.unit_rent_unit || 'dia',
         unit_rent_qty: plainCostBreakdown.unit_rent_qty || 0,
         profit_amount: (data?.profit_amount || plainCostBreakdown.profit_amount || 0) > 0 || parseFloat(subtotal_travel || 0) === 0


### PR DESCRIPTION
## Problema

El desglose de conceptos del invoice viene inflado: el servicio externo de PDF multiplica `gasoline_rate × gasoline_km` porque el backend enviaba `gasoline_unit: 'km'` por defecto. Según `control-fletes/docs/pdf-payload-spec.md` §3.4/§4, la gasolina es **monto fijo de carga manual** y `gasoline_km` es solo informativo (NO entra al cálculo).

Ejemplo del spec (Folio Renta 172): gasolina mostró `78 km × $250.00 = $19,500.00` cuando el importe correcto es `$250.00`.

## Cambios

- `services/FlotillasService.js` (`mapDocumentBody`): default `gasoline_unit` `'km'` → `'fijo'` para documentos nuevos.
- `services/PDFServices.js` (`vehicleData`): fuerza `gasoline_unit: 'fijo'` en el payload saliente, cubriendo también documentos viejos que ya tienen `'km'` persistido. `gasoline_km` se mantiene como dato informativo.

> Nota: el multiply en sí vive en el servicio externo de PDF (otro repo). Este cambio corrige el contrato del lado backend; el equipo del servicio externo debe honrar `gasoline_unit: 'fijo'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)